### PR TITLE
fix: macos return "\n"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,13 @@ mod macos;
 #[cfg(target_os = "windows")]
 mod windows;
 
+#[cfg(target_os = "linux")]
+use crate::linux::get_text as _get_text;
+#[cfg(target_os = "macos")]
+use crate::macos::get_text as _get_text;
+#[cfg(target_os = "windows")]
+use crate::windows::get_text as _get_text;
+
 /// Get the text selected by the cursor
 ///
 /// Return empty string if no text is selected or error occurred
@@ -21,12 +28,9 @@ mod windows;
 /// let text = get_text();
 /// println!("{}", text);
 /// ```
-#[cfg(target_os = "linux")]
-pub use crate::linux::get_text;
-#[cfg(target_os = "macos")]
-pub use crate::macos::get_text;
-#[cfg(target_os = "windows")]
-pub use crate::windows::get_text;
+pub fn get_text() -> String {
+    _get_text().trim().to_owned()
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
When using [napi-rs](https://napi.rs/) to convert it to a nodejs addon ([github action](https://github.com/Lete114/selection-rs/actions/runs/7306238900/job/19910760881)), I found that macOS gets `\n`

![~5V(V4DEZ)UK6QJ{B(J%KNO](https://github.com/pot-app/Selection/assets/48512251/88b41dc0-c5ce-49b0-81e3-60c613760aaf)

![Y7KH383@%S5%%{24TBNBCCH](https://github.com/pot-app/Selection/assets/48512251/adbca7c8-32ec-4055-a0f8-ab21a5d35a1d)
