### PR TITLE
Update enigo 0.1.3 to 0.2.0-rc2 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ windows = { version = "0.52.0", features = [
     "Win32_UI_Accessibility",
     "Win32_System_Com",
 ] }
-rdev = "0.5.3"
+rdev = { git = "https://github.com/fufesou/rdev" }
 arboard = "3.2.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ windows = { version = "0.52.0", features = [
     "Win32_System_Com",
 ] }
 rdev = { git = "https://github.com/fufesou/rdev" }
-arboard = "3.2.0"
+arboard = "3.3.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11-clipboard = "0.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = "0.4.20"
+log = "0.4"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.52.0", features = [
+windows = { version = "0.54", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_Foundation",
     "Win32_System_Threading",
@@ -25,8 +25,8 @@ windows = { version = "0.52.0", features = [
     "Win32_System_Com",
 ] }
 rdev = { git = "https://github.com/fufesou/rdev.git" }
-arboard = "3.3.0"
+arboard = "3.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-x11-clipboard = "0.8.1"
-wl-clipboard-rs = "0.8.0"
+x11-clipboard = "0.9"
+wl-clipboard-rs = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ windows = { version = "0.52.0", features = [
     "Win32_UI_Accessibility",
     "Win32_System_Com",
 ] }
-rdev = "0.5"
+rdev = { git = "https://github.com/fufesou/rdev.git" }
 arboard = "3.3.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ windows = { version = "0.52.0", features = [
     "Win32_UI_Accessibility",
     "Win32_System_Com",
 ] }
-rdev = { git = "https://github.com/fufesou/rdev" }
+rdev = "0.5"
 arboard = "3.3.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "selection"
-authors = ["Pylogmon"]
+authors = ["Borber"]
 description = "Get the text selected by the cursor"
-repository = "https://github.com/pot-app/Selection"
+repository = "https://github.com/Borber/selection"
 keywords = ["selection", "linux", "windows", "macos"]
 categories = ["gui"]
 license = "GPL-3.0-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ windows = { version = "0.52.0", features = [
     "Win32_UI_Accessibility",
     "Win32_System_Com",
 ] }
-enigo = "0.2.0-rc2"
+rdev = "0.5.3"
 arboard = "3.2.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,16 @@ edition = "2021"
 log = "0.4.20"
 
 [target.'cfg(windows)'.dependencies]
-windows = {version="0.52.0",features= ["Win32_UI_WindowsAndMessaging", "Win32_Foundation","Win32_System_Threading","Win32_UI_Input_KeyboardAndMouse","Win32_System_DataExchange","Win32_UI_Accessibility","Win32_System_Com"] }
-enigo = "0.1.3"
+windows = { version = "0.52.0", features = [
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_System_DataExchange",
+    "Win32_UI_Accessibility",
+    "Win32_System_Com",
+] }
+enigo = "0.2.0-rc2"
 arboard = "3.2.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -25,9 +25,8 @@ pub fn get_text() -> String {
         Ok(text) => {
             if !text.is_empty() {
                 return text;
-            } else {
-                info!("get_text_by_clipboard is empty");
             }
+            info!("get_text_by_clipboard is empty");
         }
         Err(err) => {
             error!("get_text_by_automation error:{}", err);

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -116,7 +116,7 @@ fn copy() -> Result<bool, Box<dyn Error>> {
     simulate(&EventType::KeyPress(Key::KeyC))?;
     simulate(&EventType::KeyRelease(Key::ControlRight))?;
     simulate(&EventType::KeyRelease(Key::KeyC))?;
-    std::thread::sleep(std::time::Duration::from_millis(15));
+    std::thread::sleep(std::time::Duration::from_millis(20));
     let num_after = unsafe { GetClipboardSequenceNumber() };
     Ok(num_after != num_before)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -109,9 +109,6 @@ fn get_text_by_clipboard() -> Result<String, Box<dyn Error>> {
 
 fn copy() -> Result<bool, Box<dyn Error>> {
     let num_before = unsafe { GetClipboardSequenceNumber() };
-    simulate(&EventType::KeyRelease(Key::Alt))?;
-    simulate(&EventType::KeyRelease(Key::KeyX))?;
-    simulate(&EventType::KeyRelease(Key::KeyC))?;
     simulate(&EventType::KeyPress(Key::ControlRight))?;
     simulate(&EventType::KeyPress(Key::KeyC))?;
     simulate(&EventType::KeyRelease(Key::ControlRight))?;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,6 @@
 use arboard::Clipboard;
-use enigo::{Direction, Enigo, Key, Keyboard, Settings};
 use log::{error, info};
+use rdev::{simulate, EventType, Key};
 use std::error::Error;
 use windows::Win32::System::Com::{CoCreateInstance, CoInitialize, CLSCTX_ALL};
 use windows::Win32::System::DataExchange::GetClipboardSequenceNumber;
@@ -109,19 +109,21 @@ fn get_text_by_clipboard() -> Result<String, Box<dyn Error>> {
 
 fn copy() -> Result<bool, Box<dyn Error>> {
     let num_before = unsafe { GetClipboardSequenceNumber() };
-    let mut enigo = Enigo::new(&Settings::default()).unwrap();
-    enigo.key(Key::Control, Direction::Release)?;
-    enigo.key(Key::Alt, Direction::Release)?;
-    enigo.key(Key::Shift, Direction::Release)?;
-    enigo.key(Key::Meta, Direction::Release)?;
-    enigo.key(Key::Tab, Direction::Release)?;
-    enigo.key(Key::Escape, Direction::Release)?;
-    enigo.key(Key::CapsLock, Direction::Release)?;
-    enigo.key(Key::C, Direction::Release)?;
-    enigo.key(Key::Control, Direction::Press)?;
-    enigo.key(Key::C, Direction::Click)?;
-    enigo.key(Key::Control, Direction::Release)?;
-    std::thread::sleep(std::time::Duration::from_millis(20));
+    simulate(&EventType::KeyRelease(Key::ControlLeft))?;
+    simulate(&EventType::KeyRelease(Key::ControlRight))?;
+    simulate(&EventType::KeyRelease(Key::Alt))?;
+    simulate(&EventType::KeyRelease(Key::ShiftLeft))?;
+    simulate(&EventType::KeyRelease(Key::ShiftRight))?;
+    simulate(&EventType::KeyRelease(Key::MetaLeft))?;
+    simulate(&EventType::KeyRelease(Key::Tab))?;
+    simulate(&EventType::KeyRelease(Key::Escape))?;
+    simulate(&EventType::KeyRelease(Key::CapsLock))?;
+    simulate(&EventType::KeyRelease(Key::KeyC))?;
+    simulate(&EventType::KeyPress(Key::ControlRight))?;
+    simulate(&EventType::KeyPress(Key::KeyC))?;
+    simulate(&EventType::KeyRelease(Key::ControlRight))?;
+    simulate(&EventType::KeyRelease(Key::KeyC))?;
+    std::thread::sleep(std::time::Duration::from_millis(15));
     let num_after = unsafe { GetClipboardSequenceNumber() };
     Ok(num_after != num_before)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -40,7 +40,7 @@ pub fn get_text() -> String {
 // Available for Edge, Chrome and UWP
 fn get_text_by_automation() -> Result<String, Box<dyn Error>> {
     // Init COM
-    unsafe { CoInitialize(None) }?;
+    unsafe { CoInitialize(None) }.ok()?;
     // Create IUIAutomation instance
     let auto: IUIAutomation = unsafe { CoCreateInstance(&CUIAutomation, None, CLSCTX_ALL) }?;
     // Get Focused Element

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -109,15 +109,8 @@ fn get_text_by_clipboard() -> Result<String, Box<dyn Error>> {
 
 fn copy() -> Result<bool, Box<dyn Error>> {
     let num_before = unsafe { GetClipboardSequenceNumber() };
-    simulate(&EventType::KeyRelease(Key::ControlLeft))?;
-    simulate(&EventType::KeyRelease(Key::ControlRight))?;
     simulate(&EventType::KeyRelease(Key::Alt))?;
-    simulate(&EventType::KeyRelease(Key::ShiftLeft))?;
-    simulate(&EventType::KeyRelease(Key::ShiftRight))?;
-    simulate(&EventType::KeyRelease(Key::MetaLeft))?;
-    simulate(&EventType::KeyRelease(Key::Tab))?;
-    simulate(&EventType::KeyRelease(Key::Escape))?;
-    simulate(&EventType::KeyRelease(Key::CapsLock))?;
+    simulate(&EventType::KeyRelease(Key::KeyX))?;
     simulate(&EventType::KeyRelease(Key::KeyC))?;
     simulate(&EventType::KeyPress(Key::ControlRight))?;
     simulate(&EventType::KeyPress(Key::KeyC))?;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,5 @@
 use arboard::Clipboard;
+use enigo::{Direction, Enigo, Key, Keyboard, Settings};
 use log::{error, info};
 use std::error::Error;
 use windows::Win32::System::Com::{CoCreateInstance, CoInitialize, CLSCTX_ALL};
@@ -65,7 +66,7 @@ fn get_text_by_clipboard() -> Result<String, Box<dyn Error>> {
     // Read Old Clipboard
     let old_clipboard = (Clipboard::new()?.get_text(), Clipboard::new()?.get_image());
 
-    if copy() {
+    if let Ok(true) = copy() {
         // Read New Clipboard
         let new_text = Clipboard::new()?.get_text();
 
@@ -106,22 +107,21 @@ fn get_text_by_clipboard() -> Result<String, Box<dyn Error>> {
     }
 }
 
-fn copy() -> bool {
-    use enigo::*;
+fn copy() -> Result<bool, Box<dyn Error>> {
     let num_before = unsafe { GetClipboardSequenceNumber() };
-
-    let mut enigo = Enigo::new();
-    enigo.key_up(Key::Control);
-    enigo.key_up(Key::Alt);
-    enigo.key_up(Key::Shift);
-    enigo.key_up(Key::Space);
-    enigo.key_up(Key::Meta);
-    enigo.key_up(Key::Tab);
-    enigo.key_up(Key::Escape);
-    enigo.key_up(Key::CapsLock);
-    enigo.key_up(Key::C);
-    enigo.key_sequence_parse("{+CTRL}c{-CTRL}");
-    std::thread::sleep(std::time::Duration::from_millis(100));
+    let mut enigo = Enigo::new(&Settings::default()).unwrap();
+    enigo.key(Key::Control, Direction::Release)?;
+    enigo.key(Key::Alt, Direction::Release)?;
+    enigo.key(Key::Shift, Direction::Release)?;
+    enigo.key(Key::Meta, Direction::Release)?;
+    enigo.key(Key::Tab, Direction::Release)?;
+    enigo.key(Key::Escape, Direction::Release)?;
+    enigo.key(Key::CapsLock, Direction::Release)?;
+    enigo.key(Key::C, Direction::Release)?;
+    enigo.key(Key::Control, Direction::Press)?;
+    enigo.key(Key::C, Direction::Click)?;
+    enigo.key(Key::Control, Direction::Release)?;
+    std::thread::sleep(std::time::Duration::from_millis(20));
     let num_after = unsafe { GetClipboardSequenceNumber() };
-    num_after != num_before
+    Ok(num_after != num_before)
 }


### PR DESCRIPTION
[CHANGES](https://github.com/enigo-rs/enigo/blob/main/CHANGES.md#fixed)

It is said that v0.2 is a great improvement on win 

I modified it to sleep for 50 milliseconds, and the selection text can be get normally in release mode.