### PR TITLE
Bump enigo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
-on: push
+on: 
+  workflow_dispatch:
+  push:
 
 jobs:
   check-on-linux:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.20"
 
 [target.'cfg(windows)'.dependencies]
 windows = {version="0.52.0",features= ["Win32_UI_WindowsAndMessaging", "Win32_Foundation","Win32_System_Threading","Win32_UI_Input_KeyboardAndMouse","Win32_System_DataExchange","Win32_UI_Accessibility","Win32_System_Com"] }
-enigo = "0.1.3"
+enigo = "0.2.0"
 arboard = "3.2.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -107,20 +107,25 @@ fn get_text_by_clipboard() -> Result<String, Box<dyn Error>> {
 }
 
 fn copy() -> bool {
-    use enigo::*;
+    use enigo::{
+        Direction::{Click, Press, Release},
+        Enigo, Key, Keyboard, Settings,
+    };
     let num_before = unsafe { GetClipboardSequenceNumber() };
 
-    let mut enigo = Enigo::new();
-    enigo.key_up(Key::Control);
-    enigo.key_up(Key::Alt);
-    enigo.key_up(Key::Shift);
-    enigo.key_up(Key::Space);
-    enigo.key_up(Key::Meta);
-    enigo.key_up(Key::Tab);
-    enigo.key_up(Key::Escape);
-    enigo.key_up(Key::CapsLock);
-    enigo.key_up(Key::C);
-    enigo.key_sequence_parse("{+CTRL}c{-CTRL}");
+    let mut enigo = Enigo::new(&Settings::default()).unwrap();
+    enigo.key(Key::Control, Release).unwrap();
+    enigo.key(Key::Alt, Release).unwrap();
+    enigo.key(Key::Shift, Release).unwrap();
+    enigo.key(Key::Space, Release).unwrap();
+    enigo.key(Key::Meta, Release).unwrap();
+    enigo.key(Key::Tab, Release).unwrap();
+    enigo.key(Key::Escape, Release).unwrap();
+    enigo.key(Key::CapsLock, Release).unwrap();
+    enigo.key(Key::C, Release).unwrap();
+    enigo.key(Key::Control, Press).unwrap();
+    enigo.key(Key::C, Click).unwrap();
+    enigo.key(Key::Control, Release).unwrap();
     std::thread::sleep(std::time::Duration::from_millis(100));
     let num_after = unsafe { GetClipboardSequenceNumber() };
     num_after != num_before


### PR DESCRIPTION
This updates the enigo dependency to the newest version. With the new version, there are no longer any delays between key simulations on Windows, so it should be faster to copy the text.